### PR TITLE
fix build docker action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./etc/dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |


### PR DESCRIPTION
This will fix dockerfile not found error, but you should set Username and password in Action Secrets.